### PR TITLE
Implement zooming & output path specification

### DIFF
--- a/example/visualise_test.dart
+++ b/example/visualise_test.dart
@@ -3,6 +3,11 @@ library many_points.test;
 import '../lib/many_points.dart';
 
 void main() {
+  exampleRenderSync();
+  exampleRenderAreaSync();
+}
+
+void exampleRenderSync() {
   Visualisation chart = new Visualisation();
 
   chart.addData(0, 0, 12);
@@ -11,10 +16,29 @@ void main() {
   chart.addData(20, 0, 30);
 
   ColorTransformFunction fn = (int x, int y, num value, Range xRange,
-      Range yRange, Range dataRange) {
+                               Range yRange, Range dataRange) {
     return Color.fromRgb(value * 3, 0, 0);
   };
 
   chart.setColorTransform(fn);
   chart.renderSync(21, 21);
+}
+
+void exampleRenderAreaSync() {
+  Visualisation chart = new Visualisation();
+
+  chart.addData(0, 0, 12);
+  chart.addData(20, 20, 72);
+  chart.addData(0, 20, 53);
+  chart.addData(20, 0, 30);
+  chart.addData(10, 10, 41);
+
+  ColorTransformFunction fn = (int x, int y, num value, Range xRange,
+                               Range yRange, Range dataRange) {
+    return Color.fromRgb(value * 3, 0, 0);
+  };
+
+  chart.setColorTransform(fn);
+  chart.renderSync(21, 21);
+  chart.renderAreaSync(new Range(0, 10), new Range(0, 10));
 }

--- a/lib/src/visualisation.dart
+++ b/lib/src/visualisation.dart
@@ -1,7 +1,7 @@
 part of many_points;
 
 class Visualisation {
-  final String _imagePrefix = 'output/image/';
+  String _outputFolder, _outputFilename;
 
   List<DataTransformFunction> _dataTransforms = [];
   ColorTransformFunction _colorTransform;
@@ -14,10 +14,12 @@ class Visualisation {
   Range valueRange;
   bool transformsApplied;
 
-  Visualisation() {
+  Visualisation([String outputFolder = "output/image/", String outputFilename]) {
     xRange = new Range(double.INFINITY, double.NEGATIVE_INFINITY);
     yRange = new Range(double.INFINITY, double.NEGATIVE_INFINITY);
     valueRange = new Range(double.INFINITY, double.NEGATIVE_INFINITY);
+    _outputFolder = outputFolder;
+    _outputFilename = outputFilename;
   }
 
   /// Add a data point defined by the [x] and [y] coordinates and its [value].
@@ -86,9 +88,13 @@ class Visualisation {
     if (width != -1) {
       image = copyResize(image, width, height, NEAREST);
     }
-    new io.File(_imagePrefix + new DateTime.now().toString() + '.png')
-        .create(recursive: true)
-        .then((io.File file) {
+    String filename = _outputFolder;
+    if (_outputFilename == null) {
+      filename = filename + new DateTime.now().toString() + '.png';
+    } else {
+      filename = filename + _outputFilename;
+    }
+    new io.File(filename).create(recursive: true).then((io.File file) {
       file.writeAsBytesSync(encodePng(image));
     });
   }
@@ -108,9 +114,13 @@ class Visualisation {
 //    if (width != -1) {
 //      image = copyResize(image, width, height, NEAREST);
 //    }
-    new io.File(_imagePrefix + new DateTime.now().toString() + '.png')
-        .create(recursive: true)
-        .then((io.File file) {
+    String filename = _outputFolder;
+    if (_outputFilename == null) {
+      filename = filename + new DateTime.now().toString() + '.png';
+    } else {
+      filename = filename + _outputFilename;
+    }
+    new io.File(filename).create(recursive: true).then((io.File file) {
       file.writeAsBytesSync(encodePng(image));
     });
   }
@@ -132,10 +142,16 @@ class Visualisation {
       }
     }
 
-    new io.File(_imagePrefix +
-        new DateTime.now().toString() +
-        '_${areaX.min},${areaX.max}_${areaY.min},${areaY.max}' +
-        '.png').create(recursive: true).then((io.File file) {
+    String filename = _outputFolder;
+    if (_outputFilename == null) {
+      filename = filename +
+          new DateTime.now().toString() +
+          '_${areaX.min},${areaX.max}_${areaY.min},${areaY.max}' +
+          '.png';
+    } else {
+      filename = filename + _outputFilename;
+    }
+    new io.File(filename).create(recursive: true).then((io.File file) {
       file.writeAsBytesSync(encodePng(image));
     });
   }
@@ -147,8 +163,7 @@ class Visualisation {
   void _applyTransforms() {
     // Apply the transforms only once. This allows for multiple render calls but
     // a single transforms application phase.
-    if (transformsApplied == false)
-      return;
+    if (transformsApplied == false) return;
     transformsApplied = true;
     // Go through data transforms first and apply them to every point.
     for (DataTransformFunction transform in _dataTransforms) {


### PR DESCRIPTION
Fix Issue #6 :
Add a new function that renders only the given area of the visualisation.
Make the _applyTransforms method singleton-like: it gets called only once so that multiple render calls with various parameters can be chained.

Fix Issue #3:
Allow specification of the output path through the Visualisation constructor.
